### PR TITLE
feat(auth): require JWT secret and document rotation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,5 @@ SESSION_SECRET=your-session-secret-here
 NODE_ENV=development
 PORT=3000
 
-# JWT (if using JWT authentication)
+# JWT
 JWT_SECRET=your-jwt-secret-here

--- a/api/_lib/auth.js
+++ b/api/_lib/auth.js
@@ -1,5 +1,10 @@
 import jwt from 'jsonwebtoken';
 
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
+
 export function getUserFromRequest(req) {
   try {
     // Get token from cookie or Authorization header
@@ -7,15 +12,15 @@ export function getUserFromRequest(req) {
     const cookies = Object.fromEntries(
       cookieHeader.split('; ').map(c => c.split('='))
     );
-    
+
     const token = cookies.token || req.headers.authorization?.replace('Bearer ', '');
-    
+
     if (!token) {
       return null;
     }
-    
+
     // Verify and decode JWT token
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'lechworld-jwt-secret');
+    const decoded = jwt.verify(token, JWT_SECRET);
     return {
       id: decoded.userId,
       email: decoded.email,

--- a/api/auth/login-real.js
+++ b/api/auth/login-real.js
@@ -2,6 +2,11 @@ import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { supabase } from '../_lib/supabase.js';
 
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
+
 export default async function handler(req, res) {
   // Set CORS headers
   res.setHeader('Access-Control-Allow-Credentials', 'true');
@@ -74,7 +79,7 @@ export default async function handler(req, res) {
     // Create JWT token
     const token = jwt.sign(
       { userId: user.id, email: user.email },
-      process.env.JWT_SECRET || 'lechworld-jwt-secret',
+      JWT_SECRET,
       { expiresIn: '7d' }
     );
 

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -2,6 +2,11 @@ import { createClient } from '@supabase/supabase-js';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
+
 const supabase = createClient(
   process.env.SUPABASE_URL,
   process.env.SUPABASE_SERVICE_KEY,
@@ -88,12 +93,12 @@ export default async function handler(req, res) {
 
     // Create JWT token with user info
     const token = jwt.sign(
-      { 
-        userId: user.id, 
+      {
+        userId: user.id,
         email: user.email,
         username: user.email // Use email as username since Supabase doesn't have username
       },
-      process.env.JWT_SECRET || 'lechworld-jwt-secret',
+      JWT_SECRET,
       { expiresIn: '7d' }
     );
 

--- a/context/DEPLOYMENT_GUIDE.md
+++ b/context/DEPLOYMENT_GUIDE.md
@@ -85,6 +85,12 @@ Vercel App ↔ Supabase Cloud
 - Session management is production-ready
 - API keys are environment-specific
 
+## 🔄 Secret Rotation
+
+- Rotate `JWT_SECRET` and `SESSION_SECRET` regularly to limit exposure.
+- Update these secrets in your deployment platform and redeploy the app.
+- After rotation, previously issued tokens will be invalid and users must log in again.
+
 ## ✨ Result
 
 Your app will:

--- a/server/api/auth.ts
+++ b/server/api/auth.ts
@@ -5,6 +5,11 @@ import { eq, sql, or } from 'drizzle-orm';
 import { db } from '../index.js';
 import { users } from '../../shared/schemas/database.js';
 
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
+
 const router = Router();
 
 // Register new user
@@ -93,7 +98,7 @@ router.post('/login', async (req, res) => {
     // Create JWT token for Vercel
     const token = jwt.sign(
       { userId: user.id, email: user.email },
-      process.env.JWT_SECRET || 'lechworld-jwt-secret',
+      JWT_SECRET,
       { expiresIn: '7d' }
     );
 

--- a/server/index-prod.ts
+++ b/server/index-prod.ts
@@ -3,6 +3,11 @@ import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite-prod";
 import { storage } from "./storage";
 
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
+
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,6 +18,10 @@ import notificationsRoutes from './api/notifications.js';
 // Load environment variables
 dotenv.config();
 
+if (!process.env.JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 

--- a/server/middleware/auth-vercel.ts
+++ b/server/middleware/auth-vercel.ts
@@ -1,23 +1,28 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
+
 // Middleware to check if user is authenticated
 export function requireAuth(req: Request, res: Response, next: NextFunction) {
   try {
     // Check for token in cookies or Authorization header
     const token = req.cookies?.token || req.headers.authorization?.replace('Bearer ', '');
-    
+
     if (!token) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
-    
+
     // Verify token
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'lechworld-jwt-secret') as any;
-    
+    const decoded = jwt.verify(token, JWT_SECRET) as any;
+
     // Add user info to request
     (req as any).userId = decoded.userId;
     (req as any).session = { userId: decoded.userId };
-    
+
     next();
   } catch (error) {
     return res.status(401).json({ error: 'Unauthorized' });

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -22,8 +22,8 @@ declare global {
       NODE_ENV: 'development' | 'production' | 'test';
       PORT?: string;
       
-      // JWT (optional)
-      JWT_SECRET?: string;
+      // JWT
+      JWT_SECRET: string;
     }
   }
 }


### PR DESCRIPTION
## Summary
- enforce presence of JWT_SECRET across authentication modules and server startup
- document how to rotate secrets in deployment guide
- update env example and type definitions for required JWT secret

## Testing
- `npm test` *(fails: No test files found)*
- `JWT_SECRET=test npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `JWT_SECRET=test npm run typecheck` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_688e61fe1e908325bcae73475617abde