### PR TITLE
feat: validate JWT tokens on API routes

### DIFF
--- a/api/auth/me.js
+++ b/api/auth/me.js
@@ -1,3 +1,5 @@
+import { getUserFromRequest } from '../_lib/auth.js';
+
 export default async function handler(req, res) {
   // Set CORS headers
   res.setHeader('Access-Control-Allow-Credentials', 'true');
@@ -15,25 +17,11 @@ export default async function handler(req, res) {
   }
 
   try {
-    // Check for token in cookies
-    const cookieHeader = req.headers.cookie || '';
-    const cookies = Object.fromEntries(
-      cookieHeader.split('; ').map(c => c.split('='))
-    );
-    
-    if (cookies.token && (cookies.token.startsWith('mock-jwt-token-') || cookies.token.startsWith('auth-token-'))) {
-      // Return mock user
-      res.json({ 
-        user: {
-          id: 1,
-          email: 'lech@lechworld.com',
-          username: 'lech',
-          name: 'Lech'
-        }
-      });
-    } else {
-      res.status(401).json({ error: 'Unauthorized' });
+    const user = getUserFromRequest(req);
+    if (!user) {
+      return res.status(401).json({ error: 'Unauthorized' });
     }
+    res.json({ user });
   } catch (error) {
     console.error('Get user error:', error);
     res.status(500).json({ error: 'Failed to get user' });

--- a/api/programs.js
+++ b/api/programs.js
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { getUserFromRequest } from './_lib/auth.js';
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -23,13 +24,9 @@ export default async function handler(req, res) {
     return;
   }
 
-  // Check for auth token
-  const cookieHeader = req.headers.cookie || '';
-  const cookies = Object.fromEntries(
-    cookieHeader.split('; ').map(c => c.split('='))
-  );
-  
-  if (!cookies.token) {
+  // Validate auth token
+  const user = getUserFromRequest(req);
+  if (!user) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
 


### PR DESCRIPTION
## Summary
- validate auth token in `api/programs` using `getUserFromRequest`
- verify JWT on `api/auth/me` and reject unauthorized requests

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_688e62004d5483258d4e8cf2e512b635