### PR TITLE
Scope data by JWT user and backfill IDs

### DIFF
--- a/api/dashboard.js
+++ b/api/dashboard.js
@@ -37,16 +37,21 @@ export default async function handler(req, res) {
   try {
     const userId = user.id; // Real user ID from JWT
 
-    // Get all data in parallel - ALL users see ALL family data
+    // Get all data in parallel scoped to the authenticated user
     const [
       { data: familyMembers, error: membersError },
       { data: programs, error: programsError },
-      { data: memberPrograms, error: memberProgramsError }
+      { data: memberProgramsRaw, error: memberProgramsError }
     ] = await Promise.all([
-      supabase.from('family_members').select('*'), // No user_id filter - show all family members
+      supabase.from('family_members').select('*').eq('user_id', userId),
       supabase.from('loyalty_programs').select('*'),
-      supabase.from('member_programs').select('*')
+      supabase
+        .from('member_programs')
+        .select('*, family_members!inner(user_id)')
+        .eq('family_members.user_id', userId)
     ]);
+
+    const memberPrograms = memberProgramsRaw?.map(({ family_members, ...mp }) => mp) || [];
 
     if (membersError || programsError || memberProgramsError) {
       console.error('Dashboard errors:', { membersError, programsError, memberProgramsError });
@@ -86,7 +91,7 @@ export default async function handler(req, res) {
       stats,
       familyMembers: familyMembers || [],
       programs: programs || [],
-      memberPrograms: memberPrograms || []
+      memberPrograms
     });
     
   } catch (error) {

--- a/api/members.js
+++ b/api/members.js
@@ -39,6 +39,7 @@ export default async function handler(req, res) {
       const { data: members, error } = await supabase
         .from('family_members')
         .select('*')
+        .eq('user_id', userId)
         .order('created_at', { ascending: true });
       
       if (error) {
@@ -60,7 +61,7 @@ export default async function handler(req, res) {
       const { data: newMember, error } = await supabase
         .from('family_members')
         .insert({
-          user_id: 1, // Always use user_id=1 for shared family system
+          user_id: userId,
           name,
           email,
           profile_photo: profilePhoto,

--- a/scripts/import-real-data.ts
+++ b/scripts/import-real-data.ts
@@ -33,6 +33,14 @@ const MEMBER_NAMES: Record<string, string> = {
   'LEONARDO': 'Leonardo',
 };
 
+// Map member names to user IDs in the users table
+const USER_IDS: Record<string, number> = {
+  Leonardo: 7,
+  Graciela: 8,
+  Osvandré: 9,
+  Marilise: 10,
+};
+
 async function importRealData() {
   try {
     console.log('🚀 Starting real data import...');
@@ -60,21 +68,30 @@ async function importRealData() {
     const memberIds: Record<string, number> = {};
     
     for (const [originalName, normalizedName] of Object.entries(MEMBER_NAMES)) {
+      const userId = USER_IDS[normalizedName];
+
       const { rows } = await pool.query(
-        'SELECT id FROM family_members WHERE LOWER(name) = LOWER($1)',
+        'SELECT id, user_id FROM family_members WHERE LOWER(name) = LOWER($1)',
         [normalizedName]
       );
-      
+
       if (rows.length > 0) {
         memberIds[originalName] = rows[0].id;
         console.log(`✅ Found member: ${normalizedName}`);
+        if (rows[0].user_id !== userId) {
+          await pool.query(
+            'UPDATE family_members SET user_id = $1 WHERE id = $2',
+            [userId, rows[0].id]
+          );
+          console.log(`🔄 Updated user_id for ${normalizedName}`);
+        }
       } else {
-        // Create the member
+        // Create the member with correct user_id
         const { rows: newMember } = await pool.query(
-          `INSERT INTO family_members (name, email, role, is_active) 
-           VALUES ($1, $2, $3, true) 
+          `INSERT INTO family_members (user_id, name, email, role, is_active)
+           VALUES ($1, $2, $3, $4, true)
            RETURNING id`,
-          [normalizedName, `${normalizedName.toLowerCase()}@lech.world`, 'member']
+          [userId, normalizedName, `${normalizedName.toLowerCase()}@lech.world`, 'member']
         );
         memberIds[originalName] = newMember[0].id;
         console.log(`✅ Created member: ${normalizedName}`);


### PR DESCRIPTION
## Summary
- Populate `user_id` from JWT user on member creation
- Scope dashboard queries to authenticated user's data
- Backfill `user_id` in real data import script

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: missing ESLint configuration)*
- `npm run typecheck` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_b_688e620208c083258488ab3604974297