### PR TITLE
feat: enable RLS and use anon key

### DIFF
--- a/api/_lib/auth.js
+++ b/api/_lib/auth.js
@@ -5,9 +5,12 @@ export function getUserFromRequest(req) {
     // Get token from cookie or Authorization header
     const cookieHeader = req.headers.cookie || '';
     const cookies = Object.fromEntries(
-      cookieHeader.split('; ').map(c => c.split('='))
+      cookieHeader
+        .split('; ')
+        .filter(Boolean)
+        .map(c => c.split('='))
     );
-    
+
     const token = cookies.token || req.headers.authorization?.replace('Bearer ', '');
     
     if (!token) {
@@ -19,7 +22,8 @@ export function getUserFromRequest(req) {
     return {
       id: decoded.userId,
       email: decoded.email,
-      username: decoded.username
+      username: decoded.username,
+      token
     };
   } catch (error) {
     console.error('Auth error:', error);

--- a/api/_lib/supabase.js
+++ b/api/_lib/supabase.js
@@ -1,38 +1,20 @@
 import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = process.env.SUPABASE_URL;
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_KEY;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
 
-if (!supabaseUrl || !supabaseServiceKey) {
+if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing Supabase environment variables');
 }
 
-export const supabase = createClient(supabaseUrl, supabaseServiceKey, {
-  auth: {
-    autoRefreshToken: false,
-    persistSession: false
-  }
-});
-
-// Helper function to get user from token
-export async function getUserFromToken(token) {
-  if (!token) return null;
-  
-  try {
-    // For now, decode the mock token
-    if (token.startsWith('mock-jwt-token-')) {
-      // Return mock user for testing
-      return {
-        id: 1,
-        email: 'lech@lechworld.com',
-        username: 'lech'
-      };
+export function getSupabaseClient(token) {
+  return createClient(supabaseUrl, supabaseAnonKey, {
+    global: {
+      headers: token ? { Authorization: `Bearer ${token}` } : {}
+    },
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false
     }
-    
-    // TODO: Implement real JWT verification
-    return null;
-  } catch (error) {
-    console.error('Token verification error:', error);
-    return null;
-  }
+  });
 }

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -1,17 +1,6 @@
-import { createClient } from '@supabase/supabase-js';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
-
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_KEY,
-  {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false
-    }
-  }
-);
+import { getSupabaseClient } from '../_lib/supabase.js';
 
 export default async function handler(req, res) {
   // Set CORS headers
@@ -35,13 +24,14 @@ export default async function handler(req, res) {
     
     console.log('Login attempt for:', loginIdentifier);
 
+    const supabase = getSupabaseClient();
     // Find user in Supabase
     // The users table uses the email field to store usernames
     let query = supabase.from('users').select('*');
-    
+
     // Since usernames are stored in the email field, check there
     query = query.eq('email', loginIdentifier.toLowerCase());
-    
+
     const { data: users, error } = await query.limit(1);
     
     if (error) {
@@ -57,25 +47,38 @@ export default async function handler(req, res) {
 
     console.log('Found user:', { id: user.id, email: user.email, hasPassword: !!user.password });
 
+    let token;
     // Check password
     if (!user.password || user.password === '') {
       // First-time login - set the password
       console.log('First time login, setting password');
+      token = jwt.sign(
+        {
+          userId: user.id,
+          email: user.email,
+          username: user.email
+        },
+        process.env.JWT_SECRET || 'lechworld-jwt-secret',
+        { expiresIn: '7d' }
+      );
+
+      const authedSupabase = getSupabaseClient(token);
       const hashedPassword = await bcrypt.hash(password, 10);
-      
-      const { error: updateError } = await supabase
+
+      const { error: updateError } = await authedSupabase
         .from('users')
-        .update({ 
+        .update({
           password: hashedPassword
         })
         .eq('id', user.id);
-        
+
       if (updateError) {
         console.error('Password update error:', updateError);
         return res.status(500).json({ error: 'Failed to set password' });
       }
-      
+
       console.log('Password set successfully');
+      // token already created above
     } else {
       // Verify existing password
       const isValidPassword = await bcrypt.compare(password, user.password);
@@ -84,18 +87,17 @@ export default async function handler(req, res) {
         return res.status(401).json({ error: 'Invalid credentials' });
       }
       console.log('Password verified');
-    }
 
-    // Create JWT token with user info
-    const token = jwt.sign(
-      { 
-        userId: user.id, 
-        email: user.email,
-        username: user.email // Use email as username since Supabase doesn't have username
-      },
-      process.env.JWT_SECRET || 'lechworld-jwt-secret',
-      { expiresIn: '7d' }
-    );
+      token = jwt.sign(
+        {
+          userId: user.id,
+          email: user.email,
+          username: user.email
+        },
+        process.env.JWT_SECRET || 'lechworld-jwt-secret',
+        { expiresIn: '7d' }
+      );
+    }
 
     // Set cookie with proper settings for production
     const isProduction = process.env.NODE_ENV === 'production';

--- a/api/dashboard.js
+++ b/api/dashboard.js
@@ -1,16 +1,5 @@
-import { createClient } from '@supabase/supabase-js';
 import { getUserFromRequest } from './_lib/auth.js';
-
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_KEY,
-  {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false
-    }
-  }
-);
+import { getSupabaseClient } from './_lib/supabase.js';
 
 export default async function handler(req, res) {
   // Set CORS headers
@@ -34,16 +23,18 @@ export default async function handler(req, res) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
 
+  const supabase = getSupabaseClient(user.token);
+
   try {
     const userId = user.id; // Real user ID from JWT
 
-    // Get all data in parallel - ALL users see ALL family data
+    // Get all data in parallel relying on RLS
     const [
       { data: familyMembers, error: membersError },
       { data: programs, error: programsError },
       { data: memberPrograms, error: memberProgramsError }
     ] = await Promise.all([
-      supabase.from('family_members').select('*'), // No user_id filter - show all family members
+      supabase.from('family_members').select('*'),
       supabase.from('loyalty_programs').select('*'),
       supabase.from('member_programs').select('*')
     ]);

--- a/api/members.js
+++ b/api/members.js
@@ -1,16 +1,5 @@
-import { createClient } from '@supabase/supabase-js';
 import { getUserFromRequest } from './_lib/auth.js';
-
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_KEY,
-  {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false
-    }
-  }
-);
+import { getSupabaseClient } from './_lib/supabase.js';
 
 export default async function handler(req, res) {
   // Set CORS headers
@@ -30,12 +19,11 @@ export default async function handler(req, res) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
 
+  const supabase = getSupabaseClient(user.token);
+
   try {
     if (req.method === 'GET') {
-      // Use the actual user ID from the JWT token
-      const userId = user.id;
-      
-      // Get all family members - shared access for all users
+      // Get all family members for the authenticated user
       const { data: members, error } = await supabase
         .from('family_members')
         .select('*')
@@ -60,7 +48,7 @@ export default async function handler(req, res) {
       const { data: newMember, error } = await supabase
         .from('family_members')
         .insert({
-          user_id: 1, // Always use user_id=1 for shared family system
+          user_id: userId,
           name,
           email,
           profile_photo: profilePhoto,

--- a/api/programs.js
+++ b/api/programs.js
@@ -1,15 +1,5 @@
-import { createClient } from '@supabase/supabase-js';
-
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_KEY,
-  {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false
-    }
-  }
-);
+import { getSupabaseClient } from './_lib/supabase.js';
+import { getUserFromRequest } from './_lib/auth.js';
 
 export default async function handler(req, res) {
   // Set CORS headers
@@ -23,15 +13,12 @@ export default async function handler(req, res) {
     return;
   }
 
-  // Check for auth token
-  const cookieHeader = req.headers.cookie || '';
-  const cookies = Object.fromEntries(
-    cookieHeader.split('; ').map(c => c.split('='))
-  );
-  
-  if (!cookies.token) {
+  const user = getUserFromRequest(req);
+  if (!user) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
+
+  const supabase = getSupabaseClient(user.token);
 
   try {
     if (req.method === 'GET') {

--- a/api/test-supabase.js
+++ b/api/test-supabase.js
@@ -1,6 +1,7 @@
-import { supabase } from './_lib/supabase.js';
+import { getSupabaseClient } from './_lib/supabase.js';
 
 export default async function handler(req, res) {
+  const supabase = getSupabaseClient();
   try {
     // Test connection by counting users
     const { count, error } = await supabase

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -63,3 +63,48 @@ ALTER TABLE family_members ENABLE ROW LEVEL SECURITY;
 ALTER TABLE loyalty_programs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE member_programs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE activity_logs ENABLE ROW LEVEL SECURITY;
+
+-- Policies
+CREATE POLICY "Allow public read on users for login"
+  ON users FOR SELECT
+  USING (true);
+
+CREATE POLICY "Users can update own data"
+  ON users FOR UPDATE
+  USING (auth.uid() = id)
+  WITH CHECK (auth.uid() = id);
+
+CREATE POLICY "Users can manage their family members"
+  ON family_members FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Public read for loyalty programs"
+  ON loyalty_programs FOR SELECT
+  USING (true);
+
+CREATE POLICY "Authenticated users can add programs"
+  ON loyalty_programs FOR INSERT
+  WITH CHECK (auth.role() = 'authenticated');
+
+CREATE POLICY "Users manage their member programs"
+  ON member_programs FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM family_members fm
+      WHERE fm.id = member_programs.member_id
+        AND fm.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM family_members fm
+      WHERE fm.id = member_programs.member_id
+        AND fm.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users manage their activity logs"
+  ON activity_logs FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- enforce row level security and policies for all tables
- use Supabase anon key with JWT auth context
- rely on RLS in API endpoints rather than manual filtering

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_688e620465208325ae34d40e16d545ec