### PR TITLE
Sanitize login identifier and refine auth query

### DIFF
--- a/api/auth/login-real.js
+++ b/api/auth/login-real.js
@@ -21,16 +21,21 @@ export default async function handler(req, res) {
   try {
     const { username, email, password } = req.body;
     const loginIdentifier = username || email;
-    
+
+    if (!loginIdentifier || /[^\w@.-]/.test(loginIdentifier)) {
+      return res.status(400).json({ error: 'Invalid login identifier' });
+    }
+
     console.log('Login attempt for:', loginIdentifier);
 
     // Find user in Supabase
     let query = supabase.from('users').select('*');
-    
+
     if (email) {
       query = query.eq('email', loginIdentifier);
     } else {
-      query = query.or(`email.eq.${loginIdentifier},username.eq.${loginIdentifier}`);
+      const orFilter = ['email.eq.' + loginIdentifier, 'username.eq.' + loginIdentifier].join(',');
+      query = query.or(orFilter);
     }
     
     const { data: users, error } = await query.limit(1);

--- a/server/api/auth.ts
+++ b/server/api/auth.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
-import { eq, sql, or } from 'drizzle-orm';
+import { eq, or } from 'drizzle-orm';
 import { db } from '../index.js';
 import { users } from '../../shared/schemas/database.js';
 
@@ -50,7 +50,11 @@ router.post('/login', async (req, res) => {
   try {
     const { email, username, password } = req.body;
     const loginIdentifier = email || username; // Accept either field
-    
+
+    if (!loginIdentifier || /[^\w@.-]/.test(loginIdentifier)) {
+      return res.status(400).json({ error: 'Invalid login identifier' });
+    }
+
     console.log('Login attempt for:', loginIdentifier);
 
     // Find user by email OR username


### PR DESCRIPTION
## Summary
- prevent login attempts with commas or special characters
- build Supabase OR filter from explicit eq segments

## Testing
- `npm test` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_b_688e62079df08325873c8ab97540102a