### PR TITLE
feat: restrict cors origins

### DIFF
--- a/api/auth/login-mock.js
+++ b/api/auth/login-mock.js
@@ -1,7 +1,11 @@
+import { getAllowedOrigin } from '../../utils/validate-origin.js';
+
 export default async function handler(req, res) {
-  // Set CORS headers
-  res.setHeader('Access-Control-Allow-Credentials', 'true');
-  res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
+  const origin = getAllowedOrigin(req.headers.origin);
+  if (origin) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+  }
   res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS,PATCH,DELETE,POST,PUT');
   res.setHeader('Access-Control-Allow-Headers', 'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version');
   

--- a/api/auth/login-real.js
+++ b/api/auth/login-real.js
@@ -1,11 +1,14 @@
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { supabase } from '../_lib/supabase.js';
+import { getAllowedOrigin } from '../../utils/validate-origin.js';
 
 export default async function handler(req, res) {
-  // Set CORS headers
-  res.setHeader('Access-Control-Allow-Credentials', 'true');
-  res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
+  const origin = getAllowedOrigin(req.headers.origin);
+  if (origin) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+  }
   res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS,PATCH,DELETE,POST,PUT');
   res.setHeader('Access-Control-Allow-Headers', 'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version');
   

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
+import { getAllowedOrigin } from '../../utils/validate-origin.js';
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -14,9 +15,11 @@ const supabase = createClient(
 );
 
 export default async function handler(req, res) {
-  // Set CORS headers
-  res.setHeader('Access-Control-Allow-Credentials', 'true');
-  res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
+  const origin = getAllowedOrigin(req.headers.origin);
+  if (origin) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+  }
   res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS,PATCH,DELETE,POST,PUT');
   res.setHeader('Access-Control-Allow-Headers', 'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version');
   

--- a/api/auth/me.js
+++ b/api/auth/me.js
@@ -1,7 +1,11 @@
+import { getAllowedOrigin } from '../../utils/validate-origin.js';
+
 export default async function handler(req, res) {
-  // Set CORS headers
-  res.setHeader('Access-Control-Allow-Credentials', 'true');
-  res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
+  const origin = getAllowedOrigin(req.headers.origin);
+  if (origin) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+  }
   res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS,PATCH,DELETE,POST,PUT');
   res.setHeader('Access-Control-Allow-Headers', 'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version');
   

--- a/api/dashboard.js
+++ b/api/dashboard.js
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { getUserFromRequest } from './_lib/auth.js';
+import { getAllowedOrigin } from '../utils/validate-origin.js';
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -13,9 +14,11 @@ const supabase = createClient(
 );
 
 export default async function handler(req, res) {
-  // Set CORS headers
-  res.setHeader('Access-Control-Allow-Credentials', 'true');
-  res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
+  const origin = getAllowedOrigin(req.headers.origin);
+  if (origin) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+  }
   res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS,PATCH,DELETE,POST,PUT');
   res.setHeader('Access-Control-Allow-Headers', 'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization');
   

--- a/api/members.js
+++ b/api/members.js
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { getUserFromRequest } from './_lib/auth.js';
+import { getAllowedOrigin } from '../utils/validate-origin.js';
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -13,9 +14,11 @@ const supabase = createClient(
 );
 
 export default async function handler(req, res) {
-  // Set CORS headers
-  res.setHeader('Access-Control-Allow-Credentials', 'true');
-  res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
+  const origin = getAllowedOrigin(req.headers.origin);
+  if (origin) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+  }
   res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS,PATCH,DELETE,POST,PUT');
   res.setHeader('Access-Control-Allow-Headers', 'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization');
   

--- a/api/programs.js
+++ b/api/programs.js
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { getAllowedOrigin } from '../utils/validate-origin.js';
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -12,9 +13,11 @@ const supabase = createClient(
 );
 
 export default async function handler(req, res) {
-  // Set CORS headers
-  res.setHeader('Access-Control-Allow-Credentials', 'true');
-  res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
+  const origin = getAllowedOrigin(req.headers.origin);
+  if (origin) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+  }
   res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS,PATCH,DELETE,POST,PUT');
   res.setHeader('Access-Control-Allow-Headers', 'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization');
   

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,6 +14,7 @@ import programsRoutes from './api/programs.js';
 import transactionsRoutes from './api/transactions.js';
 import dashboardRoutes from './api/dashboard.js';
 import notificationsRoutes from './api/notifications.js';
+import { getAllowedOrigin } from '../utils/validate-origin.js';
 
 // Load environment variables
 dotenv.config();
@@ -89,22 +90,19 @@ app.use(session({
 // CORS configuration for development
 if (process.env.NODE_ENV === 'development') {
   app.use((req, res, next) => {
-    // Allow requests from any origin in development
-    const origin = req.headers.origin;
+    const origin = getAllowedOrigin(req.headers.origin);
     if (origin) {
       res.header('Access-Control-Allow-Origin', origin);
-    } else {
-      res.header('Access-Control-Allow-Origin', '*');
+      res.header('Access-Control-Allow-Credentials', 'true');
     }
     res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
     res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-    res.header('Access-Control-Allow-Credentials', 'true');
-    
+
     // Handle preflight requests
     if (req.method === 'OPTIONS') {
       return res.sendStatus(200);
     }
-    
+
     next();
   });
 }

--- a/utils/validate-origin.js
+++ b/utils/validate-origin.js
@@ -1,0 +1,8 @@
+const whitelist = (process.env.CORS_ORIGIN_WHITELIST || '')
+  .split(',')
+  .map(origin => origin.trim())
+  .filter(Boolean);
+
+export function getAllowedOrigin(origin) {
+  return origin && whitelist.includes(origin) ? origin : '';
+}


### PR DESCRIPTION
## Summary
- add helper to return allowed origin from a whitelist
- apply helper across API routes and server to avoid wildcard CORS

## Testing
- `npm test` (fails: No test files found)
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_b_688e620998b88325883d966a305e6f41