### PR TITLE
feat: add rate limiting to API routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "drizzle-orm": "^0.29.3",
         "drizzle-zod": "^0.5.1",
         "express": "^4.18.2",
+        "express-rate-limit": "^6.11.2",
         "express-session": "^1.17.3",
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.316.0",
@@ -5689,6 +5690,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.11.2.tgz",
+      "integrity": "sha512-a7uwwfNTh1U60ssiIkuLFWHt4hAC5yxlLGU2VP0X4YNlyEDZAqF4tK3GD3NSitVBrCQmQ0++0uOyFOgC2y4DDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "express": "^4 || ^5"
       }
     },
     "node_modules/express-session": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "drizzle-orm": "^0.29.3",
     "drizzle-zod": "^0.5.1",
     "express": "^4.18.2",
+    "express-rate-limit": "^6.11.2",
     "express-session": "^1.17.3",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.316.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,6 +14,7 @@ import programsRoutes from './api/programs.js';
 import transactionsRoutes from './api/transactions.js';
 import dashboardRoutes from './api/dashboard.js';
 import notificationsRoutes from './api/notifications.js';
+import { authRateLimiter, dataRateLimiter } from './middleware/rate-limit.js';
 
 // Load environment variables
 dotenv.config();
@@ -23,6 +24,7 @@ const __dirname = path.dirname(__filename);
 
 // Initialize Express app
 const app = express();
+app.set('trust proxy', 1);
 // PORT should be set by the Universal Localhost Development System
 // If PORT is not set, it means the server wasn't started correctly
 const PORT = process.env.PORT;
@@ -119,12 +121,12 @@ app.get('/api/health', (req, res) => {
 });
 
 // API Routes
-app.use('/api/auth', authRoutes);
-app.use('/api/members', membersRoutes);
-app.use('/api/programs', programsRoutes);
-app.use('/api/transactions', transactionsRoutes);
-app.use('/api/dashboard', dashboardRoutes);
-app.use('/api/notifications', notificationsRoutes);
+app.use('/api/auth', authRateLimiter, authRoutes);
+app.use('/api/members', dataRateLimiter, membersRoutes);
+app.use('/api/programs', dataRateLimiter, programsRoutes);
+app.use('/api/transactions', dataRateLimiter, transactionsRoutes);
+app.use('/api/dashboard', dataRateLimiter, dashboardRoutes);
+app.use('/api/notifications', dataRateLimiter, notificationsRoutes);
 
 // Static files (for production)
 if (process.env.NODE_ENV === 'production') {

--- a/server/middleware/rate-limit.ts
+++ b/server/middleware/rate-limit.ts
@@ -1,0 +1,13 @@
+import rateLimit from 'express-rate-limit';
+
+export const authRateLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 5,
+  message: 'Too many authentication attempts, please try again later.'
+});
+
+export const dataRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100
+});
+


### PR DESCRIPTION
## Summary
- add express-rate-limit for rate control
- define auth and data rate limiters
- apply rate limiting middleware to authentication and data routes

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run typecheck` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_b_688e620fdae883259e4082f4d87c615a