### PR TITLE
Refactor auth to fetch profile on load

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,5 @@
 import { Switch, Route } from "wouter";
+import { useEffect } from "react";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
@@ -8,6 +9,7 @@ import Login from "@/pages/login";
 import NotFound from "@/pages/not-found";
 import AirlineGuide from "@/pages/airline-guide";
 import ProtectedRoute from "@/components/protected-route";
+import { useAuthStore } from "@/store/auth-store";
 
 function Router() {
   return (
@@ -30,6 +32,12 @@ function Router() {
 }
 
 function App() {
+  const initialize = useAuthStore((state) => state.initialize);
+
+  useEffect(() => {
+    initialize();
+  }, [initialize]);
+
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
@@ -42,7 +50,7 @@ function App() {
             <div className="particle w-1 h-1 top-60 right-60" style={{ animationDelay: '3s' }}></div>
             <div className="particle w-2 h-2 bottom-20 right-20" style={{ animationDelay: '4s' }}></div>
           </div>
-          
+
           <Router />
           <Toaster />
         </div>

--- a/client/src/components/protected-route.tsx
+++ b/client/src/components/protected-route.tsx
@@ -7,16 +7,16 @@ interface ProtectedRouteProps {
 }
 
 export default function ProtectedRoute({ children }: ProtectedRouteProps) {
-  const { user } = useAuthStore();
+  const { user, isLoading } = useAuthStore();
   const [, setLocation] = useLocation();
 
   useEffect(() => {
-    if (!user) {
+    if (!isLoading && !user) {
       setLocation("/login");
     }
-  }, [user, setLocation]);
+  }, [user, isLoading, setLocation]);
 
-  if (!user) {
+  if (isLoading || !user) {
     return null;
   }
 

--- a/client/src/store/auth-store.ts
+++ b/client/src/store/auth-store.ts
@@ -5,24 +5,28 @@
  * @connects-to client/src/components/navigation.tsx
  */
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
 import type { User } from "@/types/schema";
+import { getCurrentUser } from "@/services/auth";
 
 interface AuthState {
   user: User | null;
+  isLoading: boolean;
   setUser: (user: User | null) => void;
   logout: () => void;
+  initialize: () => Promise<void>;
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set) => ({
-      user: null,
-      setUser: (user) => set({ user }),
-      logout: () => set({ user: null }),
-    }),
-    {
-      name: "auth-storage",
+export const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+  isLoading: true,
+  setUser: (user) => set({ user }),
+  logout: () => set({ user: null }),
+  initialize: async () => {
+    try {
+      const currentUser = await getCurrentUser();
+      set({ user: currentUser });
+    } finally {
+      set({ isLoading: false });
     }
-  )
-);
+  },
+}));


### PR DESCRIPTION
## Summary
- remove persisted auth profile and add async initialization
- fetch profile from `/api/auth/me` when app starts
- wait for auth load before guarding routes

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run typecheck` *(fails: TypeScript reported missing dependencies and type errors)*

------
https://chatgpt.com/codex/tasks/task_b_688e6215b2d0832592d14ab2e044f34f