### PR TITLE
feat: add payload validation for members and programs APIs

### DIFF
--- a/server/api/members.ts
+++ b/server/api/members.ts
@@ -1,9 +1,27 @@
 import { Router } from 'express';
 import { eq, and } from 'drizzle-orm';
+import { z } from 'zod';
 import { db } from '../index.js';
 import { familyMembers, memberPrograms, loyaltyPrograms } from '../../shared/schema.js';
 import { requireAuth } from '../middleware/auth-vercel.js';
 import { syncToSupabase } from '../supabase-client.js';
+
+const createMemberSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  profilePhoto: z.string().url().optional(),
+  color: z.string().optional(),
+  role: z.string().optional(),
+});
+
+const updateMemberSchema = createMemberSchema.extend({
+  cpf: z.string().optional(),
+  phone: z.string().optional(),
+  birthdate: z.string().optional(),
+  frameColor: z.string().optional(),
+  frameBorderColor: z.string().optional(),
+  profileEmoji: z.string().optional(),
+}).partial();
 
 const router = Router();
 
@@ -29,11 +47,11 @@ router.get('/', async (req, res) => {
 router.post('/', async (req, res) => {
   try {
     const userId = req.session.userId!;
-    const { name, email, profilePhoto, color, role } = req.body;
-
-    if (!name) {
-      return res.status(400).json({ error: 'Name is required' });
+    const parsed = createMemberSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: 'Invalid member payload', details: parsed.error.errors });
     }
+    const { name, email, profilePhoto, color, role } = parsed.data;
 
     const [newMember] = await db.insert(familyMembers).values({
       userId,
@@ -56,10 +74,14 @@ router.put('/:id', async (req, res) => {
   try {
     const userId = req.session.userId!;
     const memberId = parseInt(req.params.id);
-    const { 
-      name, 
-      email, 
-      profilePhoto, 
+    const parsed = updateMemberSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: 'Invalid member payload', details: parsed.error.errors });
+    }
+    const {
+      name,
+      email,
+      profilePhoto,
       color,
       role,
       cpf,
@@ -68,7 +90,7 @@ router.put('/:id', async (req, res) => {
       frameColor,
       frameBorderColor,
       profileEmoji
-    } = req.body;
+    } = parsed.data;
 
     console.log('UPDATE REQUEST:', {
       memberId,

--- a/server/api/programs.ts
+++ b/server/api/programs.ts
@@ -1,8 +1,32 @@
 import { Router } from 'express';
 import { eq, and } from 'drizzle-orm';
+import { z } from 'zod';
 import { db } from '../index.js';
 import { airlines, memberPrograms, familyMembers } from '../../shared/schemas/database.js';
 import { requireAuth } from '../middleware/auth.js';
+
+const addProgramSchema = z.object({
+  airlineId: z.number(),
+  memberNumber: z.string().optional(),
+  statusLevel: z.string().optional(),
+  currentMiles: z.number().optional(),
+  pin: z.string().optional(),
+  documentNumber: z.string().optional(),
+  documentType: z.string().optional(),
+  accountPassword: z.string().optional(),
+});
+
+const updateProgramSchema = z.object({
+  memberNumber: z.string().optional(),
+  statusLevel: z.string().optional(),
+  currentMiles: z.number().optional(),
+  pin: z.string().optional(),
+  documentNumber: z.string().optional(),
+  documentType: z.string().optional(),
+  accountPassword: z.string().optional(),
+  googleWalletEnabled: z.boolean().optional(),
+  customFields: z.array(z.any()).optional(),
+}).partial();
 
 const router = Router();
 
@@ -25,16 +49,20 @@ router.post('/member/:memberId', async (req, res) => {
   try {
     const userId = req.session.userId!;
     const memberId = parseInt(req.params.memberId);
-    const { 
-      airlineId, 
-      memberNumber, 
-      statusLevel, 
+    const parsed = addProgramSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: 'Invalid program payload', details: parsed.error.errors });
+    }
+    const {
+      airlineId,
+      memberNumber,
+      statusLevel,
       currentMiles,
       pin,
       documentNumber,
       documentType,
       accountPassword
-    } = req.body;
+    } = parsed.data;
 
     // Verify member ownership
     const [member] = await db.select().from(familyMembers)
@@ -89,15 +117,19 @@ router.put('/:id', async (req, res) => {
   console.log('Program ID:', req.params.id);
   console.log('Session:', req.session);
   console.log('Body:', req.body);
-  
+
   try {
     const userId = req.session.userId!;
     const memberProgramId = parseInt(req.params.id);
     console.log('Parsed ID:', memberProgramId, 'Type:', typeof memberProgramId);
     console.log('Session userId:', userId);
-    const { 
-      memberNumber, 
-      statusLevel, 
+    const parsed = updateProgramSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: 'Invalid program payload', details: parsed.error.errors });
+    }
+    const {
+      memberNumber,
+      statusLevel,
       currentMiles,
       pin,
       documentNumber,
@@ -105,7 +137,7 @@ router.put('/:id', async (req, res) => {
       accountPassword,
       googleWalletEnabled,
       customFields
-    } = req.body;
+    } = parsed.data;
 
     // Verify ownership through member
     console.log('Checking ownership - memberProgramId:', memberProgramId, 'userId:', userId);


### PR DESCRIPTION
## Summary
- add Zod schemas for member and program payloads
- validate request bodies before DB operations and return 400 on schema errors

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_688e6211eaac8325a03fce40e81e6e50