### PR TITLE
chore: remove build settings from server vercel config

### DIFF
--- a/server/vercel.json
+++ b/server/vercel.json
@@ -15,7 +15,5 @@
       "destination": "/api/$1"
     }
   ],
-  "buildCommand": "",
-  "installCommand": "cd api && npm install",
-  "outputDirectory": null
+  "installCommand": "cd api && npm install"
 }


### PR DESCRIPTION
## Summary
- drop unused `buildCommand` and `outputDirectory` from server `vercel.json`

## Testing
- `npm test` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_b_688ecb0150748325a79f58337e340e26