### PR TITLE
chore: update vercel runtime

### DIFF
--- a/server/vercel.json
+++ b/server/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "functions": {
     "api/*.ts": {
-      "runtime": "@vercel/node"
+      "runtime": "nodejs18.x"
     }
   },
   "rewrites": [


### PR DESCRIPTION
## Summary
- specify Node.js 18 runtime for Vercel server functions

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_688ecaff21708325b41ce24917435641